### PR TITLE
WP-10386 Dependabot bump pyjwt from 2.3.0 to 2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## ## 1.6.3
+
+- Dependabot bump pyjwt to 2.4.0
+
 ## ## 1.6.2
 
 - Merge latest from singer-io/tap-shopify

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "tap-shopify"
-version = "1.6.2"
+version = "1.6.3"
 description = "Singer.io tap for extracting Shopify data"
 authors = ["Stitch"]
 homepage = "https://singer.io"


### PR DESCRIPTION
Catching up changelog, following merge of Dependabot PR.